### PR TITLE
Clean up imports and document uv usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ and save the weights again using `model.save_weights("model.h5")`.
 - [uv](https://docs.astral.sh/uv/latest/) for managing dependencies. uv is a
   drop-in replacement for `pip` and `virtualenv` that provides reproducible
   environments.
+  - macOS / Linux: `curl -Ls https://astral.sh/uv/install.sh | sh`
+  - Windows (PowerShell):
+    ```powershell
+    iwr https://astral.sh/uv/install.ps1 -useb | iex
+    ```
 - (Optional) Docker if you plan to containerise the service.
 
 ## Installation and local development
@@ -51,8 +56,14 @@ virtual environment managed by uv:
 uv sync
 ```
 
-This command reads `pyproject.toml`, creates the virtual environment, and
+The command reads `pyproject.toml`, creates the virtual environment, and
 installs TensorFlow, Flask, and the other dependencies required by the service.
+If you would like to run the exploratory notebook, include its optional
+dependencies by syncing with the `notebook` extra:
+
+```bash
+uv sync --extra notebook
+```
 
 Start the development server with:
 

--- a/demo.ipynb
+++ b/demo.ipynb
@@ -18,16 +18,11 @@
    "source": [
     "%matplotlib inline\n",
     "import numpy as np\n",
-    "import pandas as pd\n",
     "import matplotlib.pyplot as plt\n",
     "from termcolor import colored\n",
-    "import keras\n",
-    "from keras.models import Sequential\n",
-    "from keras.layers import Dense, Activation\n",
-    "from keras.optimizers import RMSprop, Adam, SGD, Nadam\n",
-    "from keras.callbacks import ModelCheckpoint, ReduceLROnPlateau, CSVLogger, EarlyStopping\n",
-    "\n",
-    "from model import def_model"
+    "from keras.callbacks import ModelCheckpoint, EarlyStopping\n",
+    "from keras.datasets import boston_housing\n",
+    "from model import def_model\n"
    ]
   },
   {
@@ -82,9 +77,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from keras.datasets import boston_housing\n",
-    "\n",
-    "(x_train, y_train), (x_test, y_test) = boston_housing.load_data()"
+    "(x_train, y_train), (x_test, y_test) = boston_housing.load_data()\n"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,12 @@ dependencies = [
     "tensorflow-cpu>=2.15,<2.17",
 ]
 
+[project.optional-dependencies]
+notebook = [
+    "matplotlib",
+    "termcolor",
+]
+
 [build-system]
 requires = ["setuptools>=68"]
 build-backend = "setuptools.build_meta"

--- a/server.py
+++ b/server.py
@@ -91,7 +91,9 @@ def _coerce_payload(payload: Any) -> np.ndarray:
     elif isinstance(payload, Iterable) and not isinstance(payload, Mapping):
         tokens = payload
     else:
-        raise BadRequest("Input must be a comma separated string or iterable of values.")
+        raise BadRequest(
+            "Input must be a comma separated string or iterable of values."
+        )
 
     values = []
     for index, item in enumerate(tokens):


### PR DESCRIPTION
## Summary
- trim unused imports from the demo notebook so the lint checks pass cleanly
- add a `notebook` optional dependency group via `uv add` for matplotlib and termcolor
- document uv installation and how to sync optional extras in the README, plus keep the codebase formatted

## Testing
- ruff check
- black --check .

------
https://chatgpt.com/codex/tasks/task_e_68d97f5c7b688324b8e9f3193c8a0682